### PR TITLE
Bypass import error

### DIFF
--- a/roles/mysql/templates/my.cnf.j2
+++ b/roles/mysql/templates/my.cnf.j2
@@ -27,6 +27,7 @@ bind-address=127.0.0.1
 {% endif %}
 
 #log_error               = error.log
+log_bin_trust_function_creators = 1
 
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0


### PR DESCRIPTION
This function has none of DETERMINISTIC, NO SQL, or READS SQL DATA in its declaration and binary logging is enabled (you _might_ want to use the less safe log_bin_trust_function_creators variable)
